### PR TITLE
Fix INVALID_HANDLE_VALUE to support x64

### DIFF
--- a/lib/win32/event.rb
+++ b/lib/win32/event.rb
@@ -25,7 +25,7 @@ module Win32
 
     private_class_method :CreateEvent, :OpenEvent, :SetEvent, :ResetEvent
 
-    INVALID_HANDLE_VALUE = 0xFFFFFFFF
+    INVALID_HANDLE_VALUE = FFI::Pointer.new(-1).address
     EVENT_ALL_ACCESS     = 0x1F0003
 
     # This is the error raised if any of the Event methods fail.

--- a/win32-event.gemspec
+++ b/win32-event.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |spec|
   spec.author     = "Daniel J. Berger"
   spec.license    = "Artistic 2.0"
   spec.email      = "djberg96@gmail.com"
-  spec.homepage   = "http://github.com/djberg96/win32-event"
+  spec.homepage   = "https://github.com/chef/win32-event"
   spec.summary    = "Interface to MS Windows Event objects."
   spec.test_file  = "test/test_win32_event.rb"
 


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

The `INVALID_HANDLE_VALUE` should be `0xFFFF_FFFF_FFFF_FFFF`(x64) rather than `0xFFFF_FFFF`(x86)

## Description
Use `FFI::Pointer.new(-1).address` to make it ruby platform independent.

## Related Issue

None

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
