### PR TITLE
chore: sync CODEOWNERS with chef/win32-certstore

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,4 @@
 # Order is important. The last matching pattern has the most precedence.
 
-*                 @chef/chef-infra-reviewers @chef/chef-infra-approvers @chef/chef-infra-owners
-.expeditor/       @chef/infra-packages
-*.md              @chef/docs-team
+*            @chef/chef-infra-reviewers @chef/chef-infra-approvers @chef/chef-infra-owners @jaymzh
+.expeditor/  @chef/build-engineering-systems-team


### PR DESCRIPTION
## Description
Aligns .github/CODEOWNERS with the configuration used in chef/win32-certstore for consistency across Chef Windows-related repos.

## Changes Made
- Default owner line (*) includes @jaymzh
- .expeditor/ owned by @chef/build-engineering-systems-team
- Removed the separate *.md -> @chef/docs-team rule (not present in win32-certstore)